### PR TITLE
Migrate datalad from duke to nvme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,6 @@ cd large
 datalad save -m "initial save"
 ```
 
-## Migrate Datalad dataset from duke to nvme joplin
-
-```bash
-# Create datalad folder
-datalad create -c text2git large
-cd /mnt/nvme/datalad/
-datalad create -c text2git large
-rsync -av --progress ~/duke/sct_testing/large/ /mnt/nvme/datalad/large/ --exclude .DS_Store --exclude .datalad/ --exclude .git*
-#Modify file to reflect version 1.0
-nano /mnt/nvme/datalad/large/CHANGES.md
-datalad save -m "initial save" --version-tag "1.0"
-```
-
 ## Nightly backup to duke
 This will be added in the cron job of the system admin since it requires grmes credentials for the mount.
 The sync has to be done before 9pm (time when nightly backup is made of duke on grappelli).


### PR DESCRIPTION
## Context
Due to issues reported here: https://github.com/neuropoly/datalad/issues/12, https://github.com/neuropoly/datalad/issues/15, https://github.com/neuropoly/datalad/issues/3 and on slack discussion, we decided to try local storage of datalad dataset on nvme on joplin with nightly backup on duke.

## Migrate Datalad dataset from duke to nvme joplin

~~~
cd /mnt/nvme/datalad/
# Create datalad folder
datalad create -c text2git large
rsync -av --progress ~/duke/sct_testing/large/ /mnt/nvme/datalad/large/ --exclude .DS_Store --exclude .datalad/ --exclude .git*
# Modify file to reflect version 1.0
nano /mnt/nvme/datalad/large/CHANGES.md
datalad save -m "initial save" --version-tag "1.0"
~~~