### PR TITLE
Move whereis advice and hide .DS_Store files

### DIFF
--- a/git-annex.md
+++ b/git-annex.md
@@ -87,8 +87,6 @@ $ git annex init
 $ git annex dead here # make sure *this* copy isn't shared to others; the repo should be shared via the server
 $ # copy in or create initial files
 $ git add .
-$ # verify your .nii.gz files were annexed
-$ git annex whereis
 $ git commit -m "Initial data"
 ```
 
@@ -98,6 +96,8 @@ $ git commit -m "Initial data"
 
 If you have any error at all, the first thing to check is that you have `git-annex` version 8, [as explained above](#installation).
 
+
+### checking annex file locations
 
 ### "a cosmetic problem affecting git status"
 

--- a/git-annex.md
+++ b/git-annex.md
@@ -81,14 +81,17 @@ $ cd my-new-repo
 $ git init
 $ vi README # write something useful in this
 $ git add README; git commit -m "Initial commit"
+$ (echo ".DS_Store") > .gitignore
 $ (echo "*   annex.largefiles=anything"; echo "*.nii.gz   filter=annex"; echo "*.nii   filter=annex"; echo "*.tif   filter=annex") > .gitattributes
-$ git add .gitattributes; git commit -m "Configure git-annex"
+$ git add .gitignore .gitattributes; git commit -m "Configure git-annex"
 $ git annex init
 $ git annex dead here # make sure *this* copy isn't shared to others; the repo should be shared via the server
 $ # copy in or create initial files
 $ git add .
 $ git commit -m "Initial data"
 ```
+
+This ensures we don't commit useless files (`.gitignore`), and saves a lot of time by only processing NIfTI images (`.gitattributes`) -- by default, git-annex reads all files even if it doesn't ultimately decide to annex them.
 
 ## Troubleshooting
 

--- a/internal-server.md
+++ b/internal-server.md
@@ -243,6 +243,8 @@ Then, to upload it, pick a name under `datasets/`, e.g. "my-new-repo", and do
 ```
 $ git remote add origin git@data.neuro.polymtl.ca:datasets/my-new-repo
 $ git annex sync --content origin
+$ # verify your .nii.gz files were annexed and uploaded
+$ git annex whereis
 ```
 
 Note that you have personal space under "CREATOR", so if your username is "zamboni" then you can:


### PR DESCRIPTION
`git annex dead here` contradicts `git annex whereis`. Both are useful, but in following the direct instructions I gave, doing them one after the other gives errors because, from its perspective, there are *no* copies of the data, but that's just because we told it not to count itself. git-annex is a bit ambiguous here.

Anyway, moving the advice over to the uploading instructions avoids the issue.