### PR TITLE
Fix dataset `data_axondeepseg_tem`

### DIFF
--- a/scripts/curate_data_axondeepseg_tem.py
+++ b/scripts/curate_data_axondeepseg_tem.py
@@ -69,7 +69,7 @@ def main(root_data, output_data):
             else:
                 # not a file we recognize
                 continue
-            shutil.copy(path_file_in, path_file_out)
+            shutil.copyfile(path_file_in, path_file_out)
 
     sub_list = sorted(d for d in os.listdir(output_data) if d.startswith("sub-"))
 

--- a/scripts/curate_data_axondeepseg_tem.py
+++ b/scripts/curate_data_axondeepseg_tem.py
@@ -69,10 +69,13 @@ def main(root_data, output_data):
                 path_file_out = os.path.join(path_sub_id_dir_out, sub_bids_full + images[file])
                 os.makedirs(path_sub_id_dir_out, exist_ok=True)
                 create_json_sidecar(path_sub_id_dir_out, sub_id + '_TEM.png')
-            if file in der:
+            elif file in der:
                 path_sub_id_dir_out = os.path.join(output_data, 'derivatives', 'labels', sub_id, 'microscopy')
                 path_file_out = os.path.join(path_sub_id_dir_out, sub_bids_full + der[file])
                 os.makedirs(path_sub_id_dir_out, exist_ok=True)
+            else:
+                # not a file we recognize
+                continue
             shutil.copy(path_file_in, path_file_out)
 
     sub_list = os.listdir(output_data)

--- a/scripts/curate_data_axondeepseg_tem.py
+++ b/scripts/curate_data_axondeepseg_tem.py
@@ -44,9 +44,6 @@ def create_json_sidecar(path_folder_sub_id_bids, item_out):
 
 
 def main(root_data, output_data):
-    # Remove macOS .DS_Store
-    subprocess.run(["find", root_data, "-name", ".DS_Store", "-type", "f", "-delete"], check=True)
-
     # Remove output_data if exists to start clean
     if os.path.isdir(output_data):
         shutil.rmtree(output_data)

--- a/scripts/curate_data_axondeepseg_tem.py
+++ b/scripts/curate_data_axondeepseg_tem.py
@@ -1,3 +1,7 @@
+"""
+This script is meant to curate smb://duke.neuro.polymtl.ca/projects/axondeepseg/20210708_default_datasets_mask_curation/TEM_dataset/ into BIDS format.
+"""
+
 import glob
 import os
 import shutil

--- a/scripts/curate_data_axondeepseg_tem.py
+++ b/scripts/curate_data_axondeepseg_tem.py
@@ -44,10 +44,6 @@ def create_json_sidecar(path_folder_sub_id_bids, item_out):
 
 
 def main(root_data, output_data):
-    # Remove output_data if exists to start clean
-    if os.path.isdir(output_data):
-        shutil.rmtree(output_data)
-    os.makedirs(output_data, exist_ok=True)
 
     contents_ds = [subdir for subdir in os.listdir(root_data) if os.path.isdir(os.path.join(root_data, subdir))]
     contents_ds.sort()
@@ -75,9 +71,7 @@ def main(root_data, output_data):
                 continue
             shutil.copy(path_file_in, path_file_out)
 
-    sub_list = os.listdir(output_data)
-    sub_list.remove('derivatives')
-    sub_list.sort()
+    sub_list = sorted(d for d in os.listdir(output_data) if d.startswith("sub-"))
 
     # Create participants.tsv and samples.tsv
     with open(output_data + '/samples.tsv', 'w') as samples, \

--- a/scripts/curate_data_axondeepseg_tem.py
+++ b/scripts/curate_data_axondeepseg_tem.py
@@ -9,6 +9,8 @@ import json
 import argparse
 import subprocess
 import csv
+from textwrap import dedent
+
 
 images = {
     "image.png": "_TEM.png"
@@ -155,16 +157,15 @@ def main(root_data, output_data):
 
         # Create README
         with open(output_data + '/README', 'w') as readme_file:
-            print("""
-    - TEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/) 
-    - 158 brain (splenium) samples from 20 mice with axon and myelin manual segmentation labels. 
-    - 20160718_nyu_mouse_25_0002 was omitted because it contained incomplete data in the folder smb://duke.neuro.polymtl.ca/projects/axondeepseg/raw_data/data_TEM/3_done/ 
-    - Original source files are located in smb://duke.neuro.polymtl.ca/histology/mouse/20160718_nyu_mouse 
-    - Our original paper (Zaimi et al. 2018), the FOV was reported to be 6x9 um^2. This is because 1) these original values were reported in the original data reference (below), and 2) our images here are slightly cropped at the bottom relative to the original data in order to remove the scale bar. 
-    - Our original paper (Zaimi et al. 2018) reported the resolution as being 0.002 micrometer, which was (for an unknown reason) rounded in the paper from the true value of 0.00236 micrometer, as reported in the original data reference (below). 
-    - Reference for the origin of the dataset: Jelescu, I. O. et al. In vivo quantification of demyelination and recovery using compartment-specific diffusion MRI metrics validated by electron microscopy. Neuroimage 132, 104–114 (2016). 
-    - BIDS version 1.6.0 - Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00) 
-    """, file=readme_file)
+            print(dedent("""\
+    - TEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
+    - 158 brain (splenium) samples from 20 mice with axon and myelin manual segmentation labels.
+    - 20160718_nyu_mouse_25_0002 was omitted because it contained incomplete data in the folder smb://duke.neuro.polymtl.ca/projects/axondeepseg/raw_data/data_TEM/3_done/
+    - Original source files are located in smb://duke.neuro.polymtl.ca/histology/mouse/20160718_nyu_mouse
+    - Our original paper (Zaimi et al. 2018), the FOV was reported to be 6x9 um^2. This is because 1) these original values were reported in the original data reference (below), and 2) our images here are slightly cropped at the bottom relative to the original data in order to remove the scale bar.
+    - Our original paper (Zaimi et al. 2018) reported the resolution as being 0.002 micrometer, which was (for an unknown reason) rounded in the paper from the true value of 0.00236 micrometer, as reported in the original data reference (below).
+    - Reference for the origin of the dataset: Jelescu, I. O. et al. In vivo quantification of demyelination and recovery using compartment-specific diffusion MRI metrics validated by electron microscopy. Neuroimage 132, 104–114 (2016).
+    - BIDS version 1.6.0 - Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)"""), file=readme_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The script had a glitch. Example here: 

```
/Users/alex/Desktop/TEM_dataset/20160718_nyu_mouse_36_0008/mask_seg-axon-manual.png
/Users/alex/data/data_axondeepseg_tem_2/derivatives/labels/sub-nyuMouse36/microscopy/sub-nyuMouse36_sample-0008_TEM_seg-axon-manual.png


/Users/alex/Desktop/TEM_dataset/20160718_nyu_mouse_36_0008/pixel_size_in_micrometer.txt
/Users/alex/data/data_axondeepseg_tem_2/derivatives/labels/sub-nyuMouse36/microscopy/sub-nyuMouse36_sample-0008_TEM_seg-axon-manual.png


/Users/alex/Desktop/TEM_dataset/20160718_nyu_mouse_36_0008/mask_seg-myelin-manual.png
/Users/alex/data/data_axondeepseg_tem_2/derivatives/labels/sub-nyuMouse36/microscopy/sub-nyuMouse36_sample-0008_TEM_seg-myelin-manual.png
```

This caused #123 .

I added the flags to copy only the correct files.

Fixes https://github.com/neuropoly/data-management/issues/123