### PR TITLE
`dcm-zurich` BIDSification

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,45 @@
+# dcm-zurich
+
+This is an MRI dataset acquired in the context of the Pro-DCM study at Balgrist University Hospital, Zurich, Switzerland.
+
+It contains spinal cord data from degenerative cervical myelopathy (DCM) subjects.
+
+## Dataset structure
+
+- sagittal T2w
+- axial T2w (top FOV)
+- axial T2w (bottom FOV)
+- sagittal T1w (not presented for all subjects)
+
+Note:
+The axial T2w (top FOV) and the axial T2w (bottom FOV) were stitched together to create a full axial T2w image during the BIDS conversion.
+The original non-stitched images are available in the `raw` folder.
+For details about the stitching, see the curation script  in the `code` folder. 
+
+## Contact Person
+
+Patrick Freund, Balgrist University Hospital, Zurich, Switzerland.
+
+## Missing data
+
+The following subjects have only a single axial T2w image --> no stitching was performed:
+sub-349399
+sub-351576
+sub-352899
+sub-616477
+sub-633679
+sub-635370
+sub-652281
+sub-700894
+sub-713075
+sub-766291
+sub-780875
+sub-784363
+sub-785027
+sub-785776
+sub-793487
+sub-793488
+
+The following subjects have no axial T2w at all:
+sub-817811
+sub-834907

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ It contains spinal cord data from degenerative cervical myelopathy (DCM) subject
 Note:
 The axial T2w (top FOV) and the axial T2w (bottom FOV) were stitched together to create a full axial T2w image during the BIDS conversion.
 The original non-stitched images are available in the `raw` folder.
-For details about the stitching, see the curation script  in the `code` folder. 
+For details about the stitching, see the curation script in the `code` folder. 
 
 ## Contact Person
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ Patrick Freund, Balgrist University Hospital, Zurich, Switzerland.
 ## Missing data
 
 The following subjects have only a single axial T2w image --> no stitching was performed:
+sub-343299
 sub-349399
 sub-351576
 sub-352899

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ It contains spinal cord data from degenerative cervical myelopathy (DCM) subject
 
 Note:
 The axial T2w (top FOV) and the axial T2w (bottom FOV) were stitched together to create a full axial T2w image during the BIDS conversion.
-The original non-stitched images are available in the `raw` folder.
+The original non-stitched images are available in the `sourcedata` folder.
 For details about the stitching, see the curation script in the `code` folder. 
 
 ## Contact Person

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,12 +7,11 @@ It contains spinal cord data from degenerative cervical myelopathy (DCM) subject
 ## Dataset structure
 
 - sagittal T2w
-- axial T2w (top FOV)
-- axial T2w (bottom FOV)
+- axial T2w
 - sagittal T1w (not presented for all subjects)
 
 Note:
-The axial T2w (top FOV) and the axial T2w (bottom FOV) were stitched together to create a full axial T2w image during the BIDS conversion.
+The axial T2w image was created by stitching the top and bottom FOV images during the BIDS conversion.
 The original non-stitched images are available in the `sourcedata` folder.
 For details about the stitching, see the curation script in the `code` folder. 
 

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -279,7 +279,7 @@ def main():
                 if image_in in path_file_in:
                     # Save 'acq-axialTop_T2w.nii.gz' and 'acq-axialBottom_T2w.nii.gz' to 'raw' folder
                     # Check if image_in contains "oben" or "unten"
-                    if "oben" in image_in or "unten" in image_in:
+                    if "Top" in image_out or "Bottom" in image_out:
                         path_subject_folder_out = os.path.join(path_output, 'raw', 'sub-' + subject, 'anat')
                     # Save 'acq-sagittal_T2w.nii.gz' and 'T1w.nii.gz' to root folder
                     else:

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -279,7 +279,7 @@ def main():
                       ' -qc ' + path_qc + ' -qc-subject sub-' + subject)
             gzip_nii(path_file_stitched)
             create_empty_json_file(path_file_stitched)
-        # Some subjects has only a single axial T2w image --> no stitching needed, just copy the file
+        # Some subjects have only a single axial T2w image --> no stitching needed, just copy the file
         else:
             logger.warning(f'Could not find t2_tse_tra_oben* and t2_tse_tra_unten* for subject {subject}')
             logger.warning(f'Checking if a single t2_tse_tra file exists for subject {subject}')

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -257,7 +257,9 @@ def main():
             path_subject_folder_out = os.path.join(path_output, 'sub-' + subject, 'anat')
             create_subject_folder_if_not_exists(path_subject_folder_out)
             path_file_stitched = os.path.join(path_subject_folder_out, 'sub-' + subject + '_acq-axial_T2w.nii')
-            os.system('sct_image -i ' + path_file_top + ' ' + path_file_bottom + ' -stitch -o ' + path_file_stitched)
+            path_qc = os.path.join(path_output, 'qc')
+            os.system('sct_image -i ' + path_file_top + ' ' + path_file_bottom + ' -stitch -o ' + path_file_stitched +
+                      ' -qc ' + path_qc + ' -qc-subject sub-' + subject)
             gzip_nii(path_file_stitched)
             create_empty_json_file(path_file_stitched)
         else:

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -65,7 +65,7 @@ hdlr = logging.StreamHandler(sys.stdout)
 logging.root.addHandler(hdlr)
 
 
-images = {
+IMAGES = {
     "t2_tse_sag_384_25mm": "acq-sagittal_T2w.nii",
     "t2_tse_tra_oben": "acq-axialTop_T2w.nii",
     "t2_tse_tra_unten": "acq-axialBottom_T2w.nii",
@@ -76,7 +76,7 @@ images = {
 # Note: sub 876921 has two t2_tse_tra_unten (t2_tse_tra_unten_0007 and t2_tse_tra_unten_0010) --> we keep t2_tse_tra_unten_0007 (using sorted(glob.glob(...)))
 
 # Note: sub 798435 has different naming convention
-images_798435 = {
+IMAGES_798435 = {
     "t2_tse_sag_384_25mmT2_TSE_SAG_384_25MM_0009": "acq-sagittal_T2w.nii",
     "t2_tse_tra_p2T2_TSE_TRA_P2_0011": "acq-axialTop_T2w.nii",
     "t2_tse_tra_p2T2_TSE_TRA_P2_0012": "acq-axialBottom_T2w.nii",
@@ -272,7 +272,9 @@ def main():
             path_file_in = glob.glob(os.path.join(path_input, subject, sequence, '*'))[0]
             # Deal with different filenames for subject 798435
             if subject == '798435':
-                images = images_798435
+                images = IMAGES_798435
+            else:
+                images = IMAGES
             for image_in, image_out in images.items():
                 if image_in in path_file_in:
                     # Save 'acq-axialTop_T2w.nii.gz' and 'acq-axialBottom_T2w.nii.gz' to 'raw' folder

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -105,6 +105,17 @@ def create_subject_folder_if_not_exists(path_subject_folder_out):
         logger.info(f'Creating directory: {path_subject_folder_out}')
 
 
+def copy_nii(path_file_in, path_file_out):
+    """
+    Copy nii file from the input dataset to the output dataset
+    :param path_file_in: path to nii file in the input dataset
+    :param path_file_out: path to nii file in the output dataset
+    """
+    shutil.copy(path_file_in, path_file_out)
+    logger.info(f'Copying: {path_file_in} --> {path_file_out}')
+    gzip_nii(path_file_out)
+
+
 def gzip_nii(path_nii):
     """
     Gzip nii file
@@ -289,10 +300,8 @@ def main():
                     create_subject_folder_if_not_exists(path_subject_folder_out)
                     # Construct path for the output file
                     path_file_out = os.path.join(path_subject_folder_out, 'sub-' + subject + '_' + image_out)
-                    # Copy nii and json files to the output dataset
-                    shutil.copy(path_file_in, path_file_out)
-                    logger.info(f'Copying: {path_file_in} --> {path_file_out}')
-                    gzip_nii(path_file_out)
+                    # Copy nii file to the output dataset
+                    copy_nii(path_file_in, path_file_out)
                     # Create an empty json sidecar file
                     create_empty_json_file(path_file_out)
         # Aggregate subjects for participants.tsv

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -4,10 +4,43 @@
 #     - sagittal T2w
 #     - axial T2w (upper (top) FOV)
 #     - axial T2w (lower (bottom) FOV)
-#     - sagittal T1w
+#     - sagittal T1w (not presented for all subjects)
 #
 # Note: axial T2w (upper (top) FOV) and axial T2w (lower (bottom) FOV) are stitched (merged) into one axial T2w file
 # Note: "non-stitched" files (axial T2w (upper (top) FOV) and axial T2w (lower (bottom) FOV)) are included under raw
+#
+# Sample of the input dcm-zurich dataset:
+# ├── 250791
+# │		├── t2_tse_sag_384_25mm_0005
+# │		│	└── s250791-113456-00001-00020-1.nii
+# │		├── t2_tse_tra_oben_0006
+# │		│	└── s250791-113720-00001-00015-1.nii
+# │		└── t2_tse_tra_unten_0007
+# │		    └── s250791-113952-00001-00015-1.nii
+# ...
+#
+# Sample of the output BIDS dataset:
+# ├── code
+# │		 └── curate_dcm-zurich.py
+# ├── dataset_description.json
+# ├── README.md
+# ├── participants.json
+# ├── participants.tsv
+# ├── raw
+# │		 ├── sub-250791
+# │		 │	 └── anat
+# │		 │	     ├── sub-250791_acq-axialBottom_T2w.json
+# │		 │	     ├── sub-250791_acq-axialBottom_T2w.nii.gz
+# │		 │	     ├── sub-250791_acq-axialTop_T2w.json
+# │		 │	     └── sub-250791_acq-axialTop_T2w.nii.gz
+# ...
+# ├── sub-250791
+# │		 └── anat
+# │		     ├── sub-250791_acq-axial_T2w.json
+# │		     ├── sub-250791_acq-axial_T2w.nii.gz
+# │		     ├── sub-250791_acq-sagittal_T2w.json
+# │		     └── sub-250791_acq-sagittal_T2w.nii.gz
+# ...
 #
 # USAGE:
 #       python3 <PATH_TO_THIS_SCRIPT>/curate_dcm-zurich.py -i <INPUT_DATASET_PATH> -o <OUTPUT_DATASET_PATH>

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -306,7 +306,7 @@ def main():
         sequences = [os.path.basename(x) for x in sorted(glob.glob(os.path.join(path_input, subject, '*')))]
         for sequence in sequences:
             # glob.glob returns a list of files --> get the first item
-            path_file_in = glob.glob(os.path.join(path_input, subject, sequence, '*'))[0]
+            path_file_in = glob.glob(os.path.join(path_input, subject, sequence, '*nii'))[0]
             # Deal with different filenames for subject 798435
             if subject == '798435':
                 images = IMAGES_798435

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -335,7 +335,6 @@ def main():
     create_participants_json(path_output)
     create_dataset_description(path_output)
     copy_script(path_output)
-    shutil.move(FNAME_LOG, os.path.join(path_output, 'code', 'bids_conversion.log'))
 
 
 if __name__ == "__main__":

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -282,8 +282,23 @@ def main():
         # Some subjects has only a single axial T2w image --> no stitching needed, just copy the file
         else:
             logger.warning(f'Could not find t2_tse_tra_oben* and t2_tse_tra_unten* for subject {subject}')
-            with open(os.path.join(path_output, 'missing_stitched_files.txt'), 'a') as txt_file:
-                txt_file.write(f'sub-{subject}: t2_tse_tra_oben* or t2_tse_tra_unten*\n')
+            logger.warning(f'Checking if a single t2_tse_tra file exists for subject {subject}')
+            path_file_in_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra*', '*nii')))
+            if path_file_in_list:
+                # Construct path for the output file
+                path_file_in = path_file_in_list[0]
+                path_subject_folder_out = os.path.join(path_output, 'sub-' + subject, 'anat')
+                create_subject_folder_if_not_exists(path_subject_folder_out)
+                path_file_out = os.path.join(path_subject_folder_out, 'sub-' + subject + '_acq-axial_T2w.nii')
+                # Copy nii file to the output dataset
+                copy_nii(path_file_in, path_file_out)
+                # Create an empty json sidecar file
+                create_empty_json_file(path_file_out)
+                with open(os.path.join(path_output, 'no_stitching.log'), 'a') as txt_file:
+                    txt_file.write(f'sub-{subject}: has only a single t2_tse_tra file --> no stitching done\n')
+            else:
+                with open(os.path.join(path_output, 'missing_files.log'), 'a') as txt_file:
+                    txt_file.write(f'sub-{subject}: no t2_tse_tra file found\n')
 
         # Deal with other sequences ('acq-sagittal_T2w.nii.gz' and 'T1w.nii.gz') and save the original non-stitched
         # images to 'raw' folder as 'acq-axialTop_T2w.nii.gz' and 'acq-axialBottom_T2w.nii.gz'

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -259,8 +259,13 @@ def main():
     for subject in subjects:
         # Deal with axial T2w images
         # Stitch 'acq-axialTop_T2w.nii.gz' and 'acq-axialBottom_T2w.nii.gz' into 'acq-axial_T2w.nii.gz'
-        path_file_top_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_oben*', '*')))
-        path_file_bottom_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_unten*', '*')))
+        if subject == '798435':
+            # This subject has a different naming convention
+            path_file_top_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_p2T2_TSE_TRA_P2_0011', '*nii')))
+            path_file_bottom_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_p2T2_TSE_TRA_P2_0012', '*nii')))
+        else:
+            path_file_top_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_oben*', '*nii')))
+            path_file_bottom_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_unten*', '*nii')))
         # Check if path_file_top and path_file_bottom are not empty. If so, we cannot create the stitched file.
         if path_file_top_list and path_file_bottom_list:
             path_file_top = path_file_top_list[0]

--- a/scripts/curate_dcm-zurich.py
+++ b/scripts/curate_dcm-zurich.py
@@ -1,0 +1,272 @@
+# Convert the input non-BIDS dcm-zurich dataset to the BIDS compatible dataset
+# The dcm-zurich dataset contains data from DCM patients:
+# Spinal cord MRI data:
+#     - sagittal T2w
+#     - axial T2w (upper (top) FOV)
+#     - axial T2w (lower (bottom) FOV)
+#     - sagittal T1w
+#
+# Note: axial T2w (upper (top) FOV) and axial T2w (lower (bottom) FOV) are stitched (merged) into one axial T2w file
+# Note: "non-stitched" files (axial T2w (upper (top) FOV) and axial T2w (lower (bottom) FOV)) are included under raw
+#
+# USAGE:
+#       python3 <PATH_TO_THIS_SCRIPT>/curate_dcm-zurich.py -i <INPUT_DATASET_PATH> -o <OUTPUT_DATASET_PATH>
+#
+# Authors: Jan Valosek
+#
+
+import os
+import sys
+import glob
+import shutil
+import json
+import argparse
+import logging
+import datetime
+import csv
+
+# Initialize logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)  # default: logging.DEBUG, logging.INFO
+hdlr = logging.StreamHandler(sys.stdout)
+logging.root.addHandler(hdlr)
+
+
+images = {
+    "t2_tse_sag_384_25mm": "acq-sagittal_T2w.nii",
+    "t2_tse_tra_oben": "acq-axialTop_T2w.nii",
+    "t2_tse_tra_unten": "acq-axialBottom_T2w.nii",
+    "t1_tse_sag_fit": "T1w.nii",
+}
+# Note: sub 323721 has t2_tse_sag_384_25mm, t2_tse_tra_oben, t2_tse_tra_unten acquired twice --> we keep the first ones (using sorted(glob.glob(...)))
+# Note: sub 842197 has also t2_tse_tra_oben_wdh --> we ignore it
+# Note: sub 876921 has two t2_tse_tra_unten (t2_tse_tra_unten_0007 and t2_tse_tra_unten_0010) --> we keep t2_tse_tra_unten_0007 (using sorted(glob.glob(...)))
+
+# Note: sub 798435 has different naming convention
+images_798435 = {
+    "t2_tse_sag_384_25mmT2_TSE_SAG_384_25MM_0009": "acq-sagittal_T2w.nii",
+    "t2_tse_tra_p2T2_TSE_TRA_P2_0011": "acq-axialTop_T2w.nii",
+    "t2_tse_tra_p2T2_TSE_TRA_P2_0012": "acq-axialBottom_T2w.nii",
+    "t1_tse_sag_p2T1_TSE_SAG_P2_0010": "T1w.nii",
+}
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description='Convert dataset to BIDS format.')
+    parser.add_argument("-i", "--path-input",
+                        help="Path to the folder containing non-BIDS dataset.",
+                        required=True)
+    parser.add_argument("-o", "--path-output",
+                        help="Path to the output folder where the BIDS dataset will be stored.",
+                        required=True)
+    return parser
+
+
+def create_subject_folder_if_not_exists(path_subject_folder_out):
+    """
+    Check if subject's folder exists in the output dataset, if not, create it
+    :param path_subject_folder_out: path to subject's folder in the output dataset
+    """
+    if not os.path.isdir(path_subject_folder_out):
+        os.makedirs(path_subject_folder_out)
+        logger.info(f'Creating directory: {path_subject_folder_out}')
+
+
+def gzip_nii(path_nii):
+    """
+    Gzip nii file
+    :param path_nii: path to the nii file
+    :return:
+    """
+    # Check if file is gzipped
+    if not path_nii.endswith('.gz'):
+        path_gz = path_nii + '.gz'
+        logger.info(f'Gzipping {path_nii} to {path_gz}')
+        os.system(f'gzip -f {path_nii}')
+
+
+def create_empty_json_file(path_file_out):
+    """
+    Create an empty json sidecar file
+    :param path_file_out: path to the output file
+    """
+    path_json_out = path_file_out.replace('.nii', '.json')
+    with open(path_json_out, 'w') as f:
+        json.dump({}, f)
+        logger.info(f'Created: {path_json_out}')
+
+
+def write_json(path_output, json_filename, data_json):
+    """
+    :param path_output: path to the output BIDS folder
+    :param json_filename: json filename, for example: participants.json
+    :param data_json: JSON formatted content
+    :return:
+    """
+    with open(os.path.join(path_output, json_filename), 'w') as json_file:
+        json.dump(data_json, json_file, indent=4)
+        # Add last newline
+        json_file.write("\n")
+        logger.info(f'{json_filename} created in {path_output}')
+
+
+def create_participants_tsv(participants_tsv_list, path_output):
+    """
+    Write participants.tsv file
+    :param participants_tsv_list: list containing [subject_out, pathology_out, subject_in, centre_in, centre_out],
+    example:[sub-torontoDCM001, DCM, 001, 01, toronto]
+    :param path_output: path to the output BIDS folder
+    :return:
+    """
+    with open(os.path.join(path_output, 'participants.tsv'), 'w') as tsv_file:
+        tsv_writer = csv.writer(tsv_file, delimiter='\t', lineterminator='\n')
+        tsv_writer.writerow(['participant_id', 'pathology'])
+        for item in participants_tsv_list:
+            tsv_writer.writerow(item)
+        logger.info(f'participants.tsv created in {path_output}')
+
+
+def create_participants_json(path_output):
+    """
+    Create participants.json file
+    :param path_output: path to the output BIDS folder
+    :return:
+    """
+    # Create participants.json
+    data_json = {
+        "participant_id": {
+            "Description": "Unique Participant ID",
+            "LongName": "Participant ID"
+        },
+        "pathology": {
+            "Description": "The diagnosis of pathology of the participant",
+            "LongName": "Pathology name",
+            "Levels": {
+                "DCM": "Degenerative Cervical Myelopathy"
+            }
+        }
+    }
+    write_json(path_output, 'participants.json', data_json)
+
+
+def create_dataset_description(path_output):
+    """
+    Create dataset_description.json file
+    :param path_output: path to the output BIDS folder
+    :return:
+    """
+    data_json = {
+        "BIDSVersion": "BIDS 1.8.0",
+        "Name": "dcm-zurich",
+        "DatasetType": "raw"
+    }
+    write_json(path_output, 'dataset_description.json', data_json)
+
+
+def copy_script(path_output):
+    """
+    Copy the script itself to the path_output/code folder
+    :param path_output: path to the output BIDS folder
+    :return:
+    """
+    path_script_in = sys.argv[0]
+    path_code = os.path.join(path_output, 'code')
+    if not os.path.isdir(path_code):
+        os.makedirs(path_code, exist_ok=True)
+    path_script_out = os.path.join(path_code, sys.argv[0].split(sep='/')[-1])
+    logger.info(f'Copying {path_script_in} to {path_script_out}')
+    shutil.copyfile(path_script_in, path_script_out)
+
+
+def main():
+    # Parse the command line arguments
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # Make sure that input args are absolute paths
+    path_input = os.path.abspath(args.path_input)
+    path_output = os.path.abspath(args.path_output)
+
+    # Check if input path is valid
+    if not os.path.isdir(path_input):
+        print(f'ERROR - {path_input} does not exist.')
+        sys.exit()
+    # Create output folder if it does not exist
+    if not os.path.isdir(path_output):
+        os.makedirs(path_output, exist_ok=True)
+
+    FNAME_LOG = os.path.join(path_output, 'bids_conversion.log')
+    # Dump log file there
+    if os.path.exists(FNAME_LOG):
+        os.remove(FNAME_LOG)
+    fh = logging.FileHandler(os.path.join(os.path.abspath(os.curdir), FNAME_LOG))
+    logging.root.addHandler(fh)
+    logger.info("INFO: log file will be saved to {}".format(FNAME_LOG))
+
+    # Print current time and date to log file
+    logger.info('\nAnalysis started at {}'.format(datetime.datetime.now()))
+
+    # Initialize list for participants.tsv
+    participants_tsv_list = list()
+
+    # Get all directories names in the input path
+    subjects = [os.path.basename(x) for x in glob.glob(os.path.join(path_input, '*'))]
+    # Loop across subjects in input dataset
+    for subject in subjects:
+        # Stitch 'acq-axialTop_T2w.nii.gz' and 'acq-axialBottom_T2w.nii.gz' into 'acq-axial_T2w.nii.gz'
+        path_file_top_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_oben*', '*')))
+        path_file_bottom_list = sorted(glob.glob(os.path.join(path_input, subject, 't2_tse_tra_unten*', '*')))
+        # Check if path_file_top and path_file_bottom are not empty. If so, we cannot create the stitched file.
+        if path_file_top_list and path_file_bottom_list:
+            path_file_top = path_file_top_list[0]
+            path_file_bottom = path_file_bottom_list[0]
+            # Construct path for the output file
+            path_subject_folder_out = os.path.join(path_output, 'sub-' + subject, 'anat')
+            create_subject_folder_if_not_exists(path_subject_folder_out)
+            path_file_stitched = os.path.join(path_subject_folder_out, 'sub-' + subject + '_acq-axial_T2w.nii')
+            os.system('sct_image -i ' + path_file_top + ' ' + path_file_bottom + ' -stitch -o ' + path_file_stitched)
+            gzip_nii(path_file_stitched)
+            create_empty_json_file(path_file_stitched)
+        else:
+            logger.warning(f'Could not find t2_tse_tra_oben* and t2_tse_tra_unten* for subject {subject}')
+            with open(os.path.join(path_output, 'missing_stitched_files.txt'), 'a') as txt_file:
+                txt_file.write(f'sub-{subject}: t2_tse_tra_oben* or t2_tse_tra_unten*\n')
+
+        # Get all sequences for this subject
+        sequences = [os.path.basename(x) for x in sorted(glob.glob(os.path.join(path_input, subject, '*')))]
+        for sequence in sequences:
+            # glob.glob returns a list of files --> get the first item
+            path_file_in = glob.glob(os.path.join(path_input, subject, sequence, '*'))[0]
+            # Deal with different filenames for subject 798435
+            if subject == '798435':
+                images = images_798435
+            for image_in, image_out in images.items():
+                if image_in in path_file_in:
+                    # Save 'acq-axialTop_T2w.nii.gz' and 'acq-axialBottom_T2w.nii.gz' to 'raw' folder
+                    # Check if image_in contains "oben" or "unten"
+                    if "oben" in image_in or "unten" in image_in:
+                        path_subject_folder_out = os.path.join(path_output, 'raw', 'sub-' + subject, 'anat')
+                    # Save 'acq-sagittal_T2w.nii.gz' and 'T1w.nii.gz' to root folder
+                    else:
+                        path_subject_folder_out = os.path.join(path_output, 'sub-' + subject, 'anat')
+                    create_subject_folder_if_not_exists(path_subject_folder_out)
+                    # Construct path for the output file
+                    path_file_out = os.path.join(path_subject_folder_out, 'sub-' + subject + '_' + image_out)
+                    # Copy nii and json files to the output dataset
+                    shutil.copy(path_file_in, path_file_out)
+                    logger.info(f'Copying: {path_file_in} --> {path_file_out}')
+                    gzip_nii(path_file_out)
+                    # Create an empty json sidecar file
+                    create_empty_json_file(path_file_out)
+        # Aggregate subjects for participants.tsv
+        participants_tsv_list.append(['sub-' + subject, 'DCM'])
+
+    create_participants_tsv(participants_tsv_list, path_output)
+    create_participants_json(path_output)
+    create_dataset_description(path_output)
+    copy_script(path_output)
+    shutil.move(FNAME_LOG, os.path.join(path_output, 'code', 'bids_conversion.log'))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Overview 

This PR discusses the BIDSification of `dcm-zurich` dataset.

Sample of the input dataset (located on joplin in `~/duke/projects/dcm-normalization/data_zurich_2023-02-22/Nifti_proCSM/Nifti_proCSM`):
```
 ├── 250791
 │	├── t2_tse_sag_384_25mm_0005
 │	│	└── s250791-113456-00001-00020-1.nii
 │	├── t2_tse_tra_oben_0006
 │	│	└── s250791-113720-00001-00015-1.nii
 │	└── t2_tse_tra_unten_0007
 │	    └── s250791-113952-00001-00015-1.nii
 ...
```

Sample of the output BIDS dataset (located on joplin in `~/extrassd1/janvalosek/dcm-zurich`):
```
 ├── code
 │	└── curate_dcm-zurich.py
 ├── dataset_description.json
 ├── README.md
 ├── participants.json
 ├── participants.tsv
 ├── sourcedata
 │	 ├── dataset_description.json
 │	 ├── sub-250791
 │	 │	 └── anat
 │	 │	     ├── sub-250791_acq-axialBottom_T2w.json
 │	 │	     ├── sub-250791_acq-axialBottom_T2w.nii.gz            # non-stitched image
 │	 │	     ├── sub-250791_acq-axialTop_T2w.json
 │	 │	     └── sub-250791_acq-axialTop_T2w.nii.gz               # non-stitched image
 ...
 ├── sub-250791
 │	 └── anat
 │	     ├── sub-250791_acq-axial_T2w.json
 │	     ├── sub-250791_acq-axial_T2w.nii.gz                          # stitched image
 │	     ├── sub-250791_acq-sagittal_T2w.json
 │	     └── sub-250791_acq-sagittal_T2w.nii.gz
...
```

[README.md](https://github.com/neuropoly/data-management/blob/jv/curate_dcm-zurich/scripts/README.md?plain=1) is provided within this PR to allow easy review.

# Stitching

Most subjects (n=121) have two T2tra images. One covers the upper cervical SC (top FOV), second covers the lower cervical SC (bottom FOV). I stitched these two images using `sct_match -stitch`:

https://github.com/neuropoly/data-management/blob/0c01dac08cbb312ab212905f795e982803892cbf/scripts/curate_dcm-zurich.py#L278-L279

I also stored the original non-stitched images under `sourcedata` folder ([point 2 of "storage of derived datasets"](https://bids-specification.readthedocs.io/en/stable/02-common-principles.html#storage-of-derived-datasets)).

I checked the QC (`~/extrassd1/janvalosek/dcm-zurich/qc`) for 121 subjects where the stitching was applied, and it looks fine.

# Checks

`bids-validator` is reasonably happy. The upload of the dataset to git-annex will be discussed in a separate issue, as usual.

Below are some checks that the number of subjects between the input and output datasets is the same.

The number of subjects in the input dataset:

```
$ cd ~/duke/projects/dcm-normalization/data_zurich_2023-02-22/Nifti_proCSM/Nifti_proCSM
$ ls -1d * | wc -l
140
```

The number of subjects in the output dataset:

```
$ cd extrassd1/janvalosek/dcm-zurich
$ ls -1d sub-* | wc -l
140
```

The number of subjects in the output dataset under `sourcedata` (i.e. subjects with two T2w axial images --> stitching was done, and the original non-stitched images are stored under `sourcedata`):

```
$ ls -1d sourcedata/sub-* | wc -l
121
```

There are also:
- 17 subjects with only a single T2w image --> no stitching was performed (see [README.md](https://github.com/neuropoly/data-management/blob/jv/curate_dcm-zurich/scripts/README.md?plain=1))
- 2 subjects with no T2w image at all (see [README.md](https://github.com/neuropoly/data-management/blob/jv/curate_dcm-zurich/scripts/README.md?plain=1))

121 + 17 + 2 = 140 (i.e. the number of subjects is the same between the input and the output datasets)
